### PR TITLE
feat: add colorcet aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ The `cmap.Colormap` object has convenience methods that allow it to be used with
 See [documentation](https://cmap-docs.readthedocs.io/en/latest/colormaps/#usage-with-external-visualization-libraries)
 for details.
 
-If you would like to see support added for a particular library, please open an issue or PR. 
+If you would like to see support added for a particular library, please open an issue or PR.
 
 ## Alternatives
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,7 +83,7 @@ source = "vcs"
 
 # https://hatch.pypa.io/latest/config/build/#file-selection
 [tool.hatch.build.targets.sdist]
-include = ["/src", "/tests"]
+include = ["/src", "/tests", "CHANGELOG.md"]
 
 
 # https://github.com/charliermarsh/ruff

--- a/src/cmap/_catalog.py
+++ b/src/cmap/_catalog.py
@@ -1,7 +1,14 @@
+"""Catalog of available colormaps.
+
+This module contains the logic that indexes all of the "record.json" files found
+in the data directory.
+
+TODO: this needs to be cleaned up, and documented better.
+"""
 from __future__ import annotations
 
 import json
-import warnings
+import logging
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, Iterator, Literal, Mapping, cast
@@ -23,12 +30,15 @@ if TYPE_CHECKING:
         tags: NotRequired[list[str]]
         interpolation: NotRequired[bool]
         info: NotRequired[str]
+        aliases: NotRequired[list[str]]
 
     class CatalogAlias(TypedDict):
         alias: str
         conflicts: NotRequired[list[str]]
 
     CatalogDict: TypeAlias = dict[str, CatalogItem]
+
+logger = logging.getLogger("cmap")
 
 
 def _norm_name(name: str) -> str:
@@ -47,6 +57,11 @@ class LoadedCatalogItem:
     authors: list[str] = field(default_factory=list)
     interpolation: bool | Interpolation = "linear"
     tags: list[str] = field(default_factory=list)
+    aliases: list[str] = field(default_factory=list)
+
+    @property
+    def qualified_name(self) -> str:
+        return f"{self.namespace}:{self.name}"
 
 
 CATALOG: dict[str, CatalogItem | CatalogAlias] = {}
@@ -62,31 +77,62 @@ def _populate_catalog() -> None:
     for r in sorted(Path(cmap.data.__file__).parent.rglob("record.json")):
         with open(r) as f:
             data = json.load(f)
+        namespace = data["namespace"]
         for name, v in data["colormaps"].items():
-            v = cast("CatalogItem | CatalogAlias", v)
-            namespaced = f"{data['namespace']}:{name}"
+            namespaced = f"{namespace}:{name}"
+
+            # if the key "alias" exists, this is a CatalogAlias.
+            # We just add it to the catalog under both the namespaced name
+            # and the short name.  The Catalog._load method will handle the resolution
+            # of the alias.
             if "alias" in v:
+                v = cast("CatalogAlias", v)
                 if ":" not in v["alias"]:  # pragma: no cover
                     raise ValueError(f"{namespaced!r} alias is not namespaced")
                 CATALOG[namespaced] = v
                 CATALOG[name] = v  # FIXME
                 continue
 
+            # otherwise we have a CatalogItem
+            v = cast("CatalogItem", v)
+
+            # here we add any global keys to the colormap that are not already there.
             for k in ("license", "namespace", "source", "authors", "category"):
                 if k in data:
                     v.setdefault(k, data[k])
 
+            # add the fully namespaced colormap to the catalog
             CATALOG[namespaced] = v
 
+            # if the short name is not already in the catalog, add it as a pointer
+            # to the fully namespaced colormap.
             if name not in CATALOG:
                 CATALOG[name] = {"alias": namespaced, "conflicts": []}
             else:
-                d_ = cast("CatalogAlias", CATALOG[name])
-                d_.setdefault("conflicts", []).append(namespaced)
+                # if the short name is already in the catalog, we have a conflict.
+                # add the fully namespaced name to the conflicts list.
+                entry = cast("CatalogAlias", CATALOG[name])
+                entry.setdefault("conflicts", []).append(namespaced)
+
+            # lastly, the `aliases` key of a colormap refers to aliases within the
+            # namespace.  These are keys that *must* be accessed using the fullly
+            # namespaced name (with a colon).  We add these to the catalog as well
+            # so that they can be
+            for alias in v.get("aliases", []):
+                if ":" in alias:  # pragma: no cover
+                    raise ValueError(
+                        f"internal alias {alias!r} in namespace {namespace} "
+                        "should not have colon."
+                    )
+                CATALOG[f"{namespace}:{alias}"] = {"alias": namespaced}
 
 
 _populate_catalog()
 _CATALOG_LOWER = {_norm_name(k): v for k, v in CATALOG.items()}
+_ALIASES: dict[str, list[str]] = {}
+for k, v in _CATALOG_LOWER.items():
+    if alias := v.get("alias"):
+        _ALIASES.setdefault(_norm_name(alias), []).append(k)  # type: ignore
 
 
 class Catalog(Mapping[str, "LoadedCatalogItem"]):
@@ -120,11 +166,10 @@ class Catalog(Mapping[str, "LoadedCatalogItem"]):
             item = cast("CatalogAlias", item)
             namespaced = item["alias"]
             if conflicts := item.get("conflicts"):
-                warnings.warn(
-                    f"The name {key!r} is an alias for {namespaced!r}, but is also "
-                    f"available as: {', '.join(conflicts)!r}. To silence this "
-                    "warning, use a fully namespaced name.",
-                    stacklevel=2,
+                logger.warning(
+                    f"WARNING: The name {key!r} is an alias for {namespaced!r}, "
+                    f"but is also available as: {', '.join(conflicts)!r}.\nTo "
+                    "silence this warning, use a fully namespaced name.",
                 )
             return self[namespaced]
 
@@ -137,6 +182,7 @@ class Catalog(Mapping[str, "LoadedCatalogItem"]):
             # well tested on internal data though
             mod = __import__(module, fromlist=[attr])
             _item["data"] = getattr(mod, attr)
+        _item["aliases"] = _ALIASES.get(key, [])
         return LoadedCatalogItem(name=key.split(":", 1)[-1], **_item)
 
 

--- a/src/cmap/_catalog.py
+++ b/src/cmap/_catalog.py
@@ -81,7 +81,8 @@ def _populate_catalog() -> None:
             if name not in CATALOG:
                 CATALOG[name] = {"alias": namespaced, "conflicts": []}
             else:
-                cast("CatalogAlias", CATALOG[name])["conflicts"].append(namespaced)
+                d_ = cast("CatalogAlias", CATALOG[name])
+                d_.setdefault("conflicts", []).append(namespaced)
 
 
 _populate_catalog()

--- a/src/cmap/_external.py
+++ b/src/cmap/_external.py
@@ -165,7 +165,8 @@ def rich_print_colormap(cm: Colormap, width: int | None = None) -> None:
     if cm.interpolation == "nearest":
         width = len(cm.color_stops)
     else:
-        width or (console.width - 12)
+        width = width or (console.width - 12)
+    width = min(width, console.width - 12)
     for color in cm.iter_colors(width):
         color_cell += Text(" ", style=Style(bgcolor=color.hex[:7]))
     console.print(color_cell)

--- a/src/cmap/_external.py
+++ b/src/cmap/_external.py
@@ -166,7 +166,6 @@ def rich_print_colormap(cm: Colormap, width: int | None = None) -> None:
         width = len(cm.color_stops)
     else:
         width = width or (console.width - 12)
-    width = min(width, console.width - 12)
     for color in cm.iter_colors(width):
         color_cell += Text(" ", style=Style(bgcolor=color.hex[:7]))
     console.print(color_cell)

--- a/src/cmap/data/colorcet/record.json
+++ b/src/cmap/data/colorcet/record.json
@@ -3,6 +3,66 @@
     "Peter Kovesi"
   ],
   "colormaps": {
+    "C01": {
+      "alias": "colorcet:CET_C1"
+    },
+    "C02": {
+      "alias": "colorcet:CET_C2"
+    },
+    "C03": {
+      "alias": "colorcet:CET_C3"
+    },
+    "C04": {
+      "alias": "colorcet:CET_C4"
+    },
+    "C05": {
+      "alias": "colorcet:CET_C5"
+    },
+    "C06": {
+      "alias": "colorcet:CET_C6"
+    },
+    "C07": {
+      "alias": "colorcet:CET_C7"
+    },
+    "C08": {
+      "alias": "colorcet:CET_C8"
+    },
+    "C09": {
+      "alias": "colorcet:CET_C9"
+    },
+    "C1": {
+      "alias": "colorcet:CET_C1"
+    },
+    "C10": {
+      "alias": "colorcet:CET_C10"
+    },
+    "C11": {
+      "alias": "colorcet:CET_C11"
+    },
+    "C2": {
+      "alias": "colorcet:CET_C2"
+    },
+    "C3": {
+      "alias": "colorcet:CET_C3"
+    },
+    "C4": {
+      "alias": "colorcet:CET_C4"
+    },
+    "C5": {
+      "alias": "colorcet:CET_C5"
+    },
+    "C6": {
+      "alias": "colorcet:CET_C6"
+    },
+    "C7": {
+      "alias": "colorcet:CET_C7"
+    },
+    "C8": {
+      "alias": "colorcet:CET_C8"
+    },
+    "C9": {
+      "alias": "colorcet:CET_C9"
+    },
     "CET_C1": {
       "category": "cyclic",
       "data": "cmap.data.colorcet.CET_C1:data",
@@ -405,6 +465,537 @@
       "category": "miscellaneous",
       "data": "cmap.data.colorcet.CET_R4:data",
       "info": "Rainbow colour map from blue to red.  Note there is a small perceptual blind spot at yellow"
+    },
+    "D01": {
+      "alias": "colorcet:CET_D1"
+    },
+    "D01A": {
+      "alias": "colorcet:CET_D1A"
+    },
+    "D02": {
+      "alias": "colorcet:CET_D2"
+    },
+    "D03": {
+      "alias": "colorcet:CET_D3"
+    },
+    "D04": {
+      "alias": "colorcet:CET_D4"
+    },
+    "D05": {
+      "alias": "colorcet:CET_D5"
+    },
+    "D06": {
+      "alias": "colorcet:CET_D6"
+    },
+    "D07": {
+      "alias": "colorcet:CET_D7"
+    },
+    "D08": {
+      "alias": "colorcet:CET_D8"
+    },
+    "D09": {
+      "alias": "colorcet:CET_D9"
+    },
+    "D1": {
+      "alias": "colorcet:CET_D1"
+    },
+    "D10": {
+      "alias": "colorcet:CET_D10"
+    },
+    "D11": {
+      "alias": "colorcet:CET_D11"
+    },
+    "D12": {
+      "alias": "colorcet:CET_D12"
+    },
+    "D13": {
+      "alias": "colorcet:CET_D13"
+    },
+    "D1A": {
+      "alias": "colorcet:CET_D1A"
+    },
+    "D2": {
+      "alias": "colorcet:CET_D2"
+    },
+    "D3": {
+      "alias": "colorcet:CET_D3"
+    },
+    "D4": {
+      "alias": "colorcet:CET_D4"
+    },
+    "D5": {
+      "alias": "colorcet:CET_D5"
+    },
+    "D6": {
+      "alias": "colorcet:CET_D6"
+    },
+    "D7": {
+      "alias": "colorcet:CET_D7"
+    },
+    "D8": {
+      "alias": "colorcet:CET_D8"
+    },
+    "D9": {
+      "alias": "colorcet:CET_D9"
+    },
+    "I01": {
+      "alias": "colorcet:CET_I1"
+    },
+    "I02": {
+      "alias": "colorcet:CET_I2"
+    },
+    "I03": {
+      "alias": "colorcet:CET_I3"
+    },
+    "I1": {
+      "alias": "colorcet:CET_I1"
+    },
+    "I2": {
+      "alias": "colorcet:CET_I2"
+    },
+    "I3": {
+      "alias": "colorcet:CET_I3"
+    },
+    "L01": {
+      "alias": "colorcet:CET_L1"
+    },
+    "L02": {
+      "alias": "colorcet:CET_L2"
+    },
+    "L03": {
+      "alias": "colorcet:CET_L3"
+    },
+    "L04": {
+      "alias": "colorcet:CET_L4"
+    },
+    "L05": {
+      "alias": "colorcet:CET_L5"
+    },
+    "L06": {
+      "alias": "colorcet:CET_L6"
+    },
+    "L07": {
+      "alias": "colorcet:CET_L7"
+    },
+    "L08": {
+      "alias": "colorcet:CET_L8"
+    },
+    "L09": {
+      "alias": "colorcet:CET_L9"
+    },
+    "L1": {
+      "alias": "colorcet:CET_L1"
+    },
+    "L10": {
+      "alias": "colorcet:CET_L10"
+    },
+    "L11": {
+      "alias": "colorcet:CET_L11"
+    },
+    "L12": {
+      "alias": "colorcet:CET_L12"
+    },
+    "L13": {
+      "alias": "colorcet:CET_L13"
+    },
+    "L14": {
+      "alias": "colorcet:CET_L14"
+    },
+    "L15": {
+      "alias": "colorcet:CET_L15"
+    },
+    "L16": {
+      "alias": "colorcet:CET_L16"
+    },
+    "L17": {
+      "alias": "colorcet:CET_L17"
+    },
+    "L18": {
+      "alias": "colorcet:CET_L18"
+    },
+    "L19": {
+      "alias": "colorcet:CET_L19"
+    },
+    "L2": {
+      "alias": "colorcet:CET_L2"
+    },
+    "L20": {
+      "alias": "colorcet:CET_L20"
+    },
+    "L3": {
+      "alias": "colorcet:CET_L3"
+    },
+    "L4": {
+      "alias": "colorcet:CET_L4"
+    },
+    "L5": {
+      "alias": "colorcet:CET_L5"
+    },
+    "L6": {
+      "alias": "colorcet:CET_L6"
+    },
+    "L7": {
+      "alias": "colorcet:CET_L7"
+    },
+    "L8": {
+      "alias": "colorcet:CET_L8"
+    },
+    "L9": {
+      "alias": "colorcet:CET_L9"
+    },
+    "R01": {
+      "alias": "colorcet:CET_R1"
+    },
+    "R02": {
+      "alias": "colorcet:CET_R2"
+    },
+    "R03": {
+      "alias": "colorcet:CET_R3"
+    },
+    "R04": {
+      "alias": "colorcet:CET_R4"
+    },
+    "R1": {
+      "alias": "colorcet:CET_R1"
+    },
+    "R2": {
+      "alias": "colorcet:CET_R2"
+    },
+    "R3": {
+      "alias": "colorcet:CET_R3"
+    },
+    "R4": {
+      "alias": "colorcet:CET_R4"
+    },
+    "bgyw": {
+      "alias": "colorcet:CET_L9"
+    },
+    "bjr": {
+      "alias": "colorcet:CET_D8"
+    },
+    "bjy": {
+      "alias": "colorcet:CET_D7"
+    },
+    "bkr": {
+      "alias": "colorcet:CET_D4"
+    },
+    "bky": {
+      "alias": "colorcet:CET_D6"
+    },
+    "blueternary": {
+      "alias": "colorcet:CET_L15"
+    },
+    "bmw": {
+      "alias": "colorcet:CET_L7"
+    },
+    "bmy": {
+      "alias": "colorcet:CET_L8"
+    },
+    "bwg": {
+      "alias": "colorcet:CET_D13"
+    },
+    "bwr": {
+      "alias": "colorcet:CET_D1"
+    },
+    "bwra": {
+      "alias": "colorcet:CET_D1A"
+    },
+    "coolwarm": {
+      "alias": "colorcet:CET_D1"
+    },
+    "cyclic-isoluminant colour circle_mgbm_67_c31_n256": {
+      "alias": "colorcet:CET_C10"
+    },
+    "cyclic-protanopic-deuteranopic_bwyk_16-96_c31_n256": {
+      "alias": "colorcet:CET_CBC1"
+    },
+    "cyclic-protanopic-deuteranopic_wywb_55-96_c33_n256": {
+      "alias": "colorcet:CET_CBC2"
+    },
+    "cyclic-tritanopic_cwrk_40-100_c20_n256": {
+      "alias": "colorcet:CET_CBTC1"
+    },
+    "cyclic-tritanopic_wrwc_70-100_c20_n256": {
+      "alias": "colorcet:CET_CBTC2"
+    },
+    "cyclic_bgrmb_35-70_c75_n256": {
+      "alias": "colorcet:CET_C11"
+    },
+    "cyclic_grey_15-85_c0_n256": {
+      "alias": "colorcet:CET_C5"
+    },
+    "cyclic_mrybm_35-75_c68_n256": {
+      "alias": "colorcet:CET_C1"
+    },
+    "cyclic_mybm_20-100_c48_n256": {
+      "alias": "colorcet:CET_C9"
+    },
+    "cyclic_mygbm_30-95_c78_n256": {
+      "alias": "colorcet:CET_C2"
+    },
+    "cyclic_mygbm_50-90_c46_n256": {
+      "alias": "colorcet:CET_C8"
+    },
+    "cyclic_rygcbmr_50-90_c64_n256": {
+      "alias": "colorcet:CET_C6"
+    },
+    "cyclic_wrkbw_10-90_c43_n256": {
+      "alias": "colorcet:CET_C3"
+    },
+    "cyclic_wrwbw_40-90_c42_n256": {
+      "alias": "colorcet:CET_C4"
+    },
+    "cyclic_ymcgy_60-90_c67_n256": {
+      "alias": "colorcet:CET_C7"
+    },
+    "cyclicgrey": {
+      "alias": "colorcet:CET_C5"
+    },
+    "depth": {
+      "alias": "colorcet:CET_L12"
+    },
+    "divbjy": {
+      "alias": "colorcet:CET_D7"
+    },
+    "diverging-isoluminant_cjm_75_c23_n256": {
+      "alias": "colorcet:CET_D12"
+    },
+    "diverging-isoluminant_cjo_70_c25_n256": {
+      "alias": "colorcet:CET_D11"
+    },
+    "diverging-linear-protanopic-deuteranopic_bjy_57-89_c34_n256": {
+      "alias": "colorcet:CET_CBD2"
+    },
+    "diverging-linear_bjr_30-55_c53_n256": {
+      "alias": "colorcet:CET_D8"
+    },
+    "diverging-linear_bjy_30-90_c45_n256": {
+      "alias": "colorcet:CET_D7"
+    },
+    "diverging-protanopic-deuteranopic_bwy_60-95_c32_n256": {
+      "alias": "colorcet:CET_CBD1"
+    },
+    "diverging-rainbow_bgymr_45-85_c67_n256": {
+      "alias": "colorcet:CET_R3"
+    },
+    "diverging-tritanopic_cwr_75-98_c20_n256": {
+      "alias": "colorcet:CET_CBTD1"
+    },
+    "diverging_bkr_55-10_c35_n256": {
+      "alias": "colorcet:CET_D4"
+    },
+    "diverging_bky_60-10_c30_n256": {
+      "alias": "colorcet:CET_D6"
+    },
+    "diverging_bwg_20-95_c41_n256": {
+      "alias": "colorcet:CET_D13"
+    },
+    "diverging_bwr_20-95_c54_n256": {
+      "alias": "colorcet:CET_D1A"
+    },
+    "diverging_bwr_40-95_c42_n256": {
+      "alias": "colorcet:CET_D1"
+    },
+    "diverging_bwr_55-98_c37_n256": {
+      "alias": "colorcet:CET_D9"
+    },
+    "diverging_cwm_80-100_c22_n256": {
+      "alias": "colorcet:CET_D10"
+    },
+    "diverging_gkr_60-10_c40_n256": {
+      "alias": "colorcet:CET_D5"
+    },
+    "diverging_gwr_55-95_c38_n256": {
+      "alias": "colorcet:CET_D3"
+    },
+    "diverging_gwv_55-95_c39_n256": {
+      "alias": "colorcet:CET_D2"
+    },
+    "fire": {
+      "alias": "colorcet:CET_L3"
+    },
+    "geographic": {
+      "alias": "colorcet:CET_L10"
+    },
+    "geographic2": {
+      "alias": "colorcet:CET_L11"
+    },
+    "gkr": {
+      "alias": "colorcet:CET_D5"
+    },
+    "gouldian": {
+      "alias": "colorcet:CET_L20"
+    },
+    "gray": {
+      "alias": "colorcet:CET_L1"
+    },
+    "greenternary": {
+      "alias": "colorcet:CET_L14"
+    },
+    "grey": {
+      "alias": "colorcet:CET_L1"
+    },
+    "gwr": {
+      "alias": "colorcet:CET_D3"
+    },
+    "gwv": {
+      "alias": "colorcet:CET_D2"
+    },
+    "heat": {
+      "alias": "colorcet:CET_L3"
+    },
+    "isoluminant_cgo_70_c39_n256": {
+      "alias": "colorcet:CET_I1"
+    },
+    "isoluminant_cgo_80_c38_n256": {
+      "alias": "colorcet:CET_I2"
+    },
+    "isoluminant_cm_70_c39_n256": {
+      "alias": "colorcet:CET_I3"
+    },
+    "kbc": {
+      "alias": "colorcet:CET_L6"
+    },
+    "kbgyw": {
+      "alias": "colorcet:CET_L16"
+    },
+    "kgy": {
+      "alias": "colorcet:CET_L5"
+    },
+    "kry": {
+      "alias": "colorcet:CET_L4"
+    },
+    "kryw": {
+      "alias": "colorcet:CET_L3"
+    },
+    "linear-protanopic-deuteranopic_kbjyw_5-95_c25_n256": {
+      "alias": "colorcet:CET_CBL1"
+    },
+    "linear-protanopic-deuteranopic_kbw_5-95_c34_n256": {
+      "alias": "colorcet:CET_CBL3"
+    },
+    "linear-protanopic-deuteranopic_kbw_5-98_c40_n256": {
+      "alias": "colorcet:CET_CBL2"
+    },
+    "linear-protanopic-deuteranopic_kyw_5-95_c49_n256": {
+      "alias": "colorcet:CET_CBL4"
+    },
+    "linear-tritanopic_kcw_5-95_c22_n256": {
+      "alias": "colorcet:CET_CBTL3"
+    },
+    "linear-tritanopic_krjcw_5-95_c24_n256": {
+      "alias": "colorcet:CET_CBTL2"
+    },
+    "linear-tritanopic_krjcw_5-98_c46_n256": {
+      "alias": "colorcet:CET_CBTL1"
+    },
+    "linear-tritanopic_krw_5-95_c46_n256": {
+      "alias": "colorcet:CET_CBTL4"
+    },
+    "linear_bgyw_20-98_c66_n256": {
+      "alias": "colorcet:CET_L9"
+    },
+    "linear_blue_95-50_c20_n256": {
+      "alias": "colorcet:CET_L12"
+    },
+    "linear_bmw_5-95_c86_n256": {
+      "alias": "colorcet:CET_L7"
+    },
+    "linear_bmy_10-95_c71_n256": {
+      "alias": "colorcet:CET_L8"
+    },
+    "linear_gow_60-85_c27_n256": {
+      "alias": "colorcet:CET_L10"
+    },
+    "linear_gow_65-90_c35_n256": {
+      "alias": "colorcet:CET_L11"
+    },
+    "linear_grey_0-100_c0_n256": {
+      "alias": "colorcet:CET_L1"
+    },
+    "linear_grey_10-95_c0_n256": {
+      "alias": "colorcet:CET_L2"
+    },
+    "linear_kbc_5-95_c73_n256": {
+      "alias": "colorcet:CET_L6"
+    },
+    "linear_kbgoy_20-95_c57_n256": {
+      "alias": "colorcet:CET_L20"
+    },
+    "linear_kbgyw_10-98_c63_n256": {
+      "alias": "colorcet:CET_L16"
+    },
+    "linear_kgy_5-95_c69_n256": {
+      "alias": "colorcet:CET_L5"
+    },
+    "linear_kry_0-97_c73_n256": {
+      "alias": "colorcet:CET_L4"
+    },
+    "linear_kryw_0-100_c71_n256": {
+      "alias": "colorcet:CET_L3"
+    },
+    "linear_ternary-blue_0-44_c57_n256": {
+      "alias": "colorcet:CET_L15"
+    },
+    "linear_ternary-green_0-46_c42_n256": {
+      "alias": "colorcet:CET_L14"
+    },
+    "linear_ternary-red_0-50_c52_n256": {
+      "alias": "colorcet:CET_L13"
+    },
+    "linear_wcmr_100-45_c42_n256": {
+      "alias": "colorcet:CET_L19"
+    },
+    "linear_worb_100-25_c53_n256": {
+      "alias": "colorcet:CET_L17"
+    },
+    "linear_wyor_100-45_c55_n256": {
+      "alias": "colorcet:CET_L18"
+    },
+    "phase2": {
+      "alias": "colorcet:CET_C4"
+    },
+    "phase4": {
+      "alias": "colorcet:CET_C2"
+    },
+    "rainbow": {
+      "alias": "colorcet:CET_R1"
+    },
+    "rainbow2": {
+      "alias": "colorcet:CET_R2"
+    },
+    "rainbow3": {
+      "alias": "colorcet:CET_R3"
+    },
+    "rainbow4": {
+      "alias": "colorcet:CET_R4"
+    },
+    "rainbow_bgyr_10-90_c83_n256": {
+      "alias": "colorcet:CET_R4"
+    },
+    "rainbow_bgyr_35-85_c72_n256": {
+      "alias": "colorcet:CET_R2"
+    },
+    "rainbow_bgyrm_35-85_c69_n256": {
+      "alias": "colorcet:CET_R1"
+    },
+    "redternary": {
+      "alias": "colorcet:CET_L13"
+    },
+    "reducedgrey": {
+      "alias": "colorcet:CET_L2"
+    },
+    "wcmr": {
+      "alias": "colorcet:CET_L19"
+    },
+    "worb": {
+      "alias": "colorcet:CET_L17"
+    },
+    "wyor": {
+      "alias": "colorcet:CET_L18"
+    },
+    "yellowheat": {
+      "alias": "colorcet:CET_L4"
     }
   },
   "license": "CC-BY-4.0",

--- a/src/cmap/data/colorcet/record.json
+++ b/src/cmap/data/colorcet/record.json
@@ -3,122 +3,101 @@
     "Peter Kovesi"
   ],
   "colormaps": {
-    "C01": {
-      "alias": "colorcet:CET_C1"
-    },
-    "C02": {
-      "alias": "colorcet:CET_C2"
-    },
-    "C03": {
-      "alias": "colorcet:CET_C3"
-    },
-    "C04": {
-      "alias": "colorcet:CET_C4"
-    },
-    "C05": {
-      "alias": "colorcet:CET_C5"
-    },
-    "C06": {
-      "alias": "colorcet:CET_C6"
-    },
-    "C07": {
-      "alias": "colorcet:CET_C7"
-    },
-    "C08": {
-      "alias": "colorcet:CET_C8"
-    },
-    "C09": {
-      "alias": "colorcet:CET_C9"
-    },
-    "C1": {
-      "alias": "colorcet:CET_C1"
-    },
-    "C10": {
-      "alias": "colorcet:CET_C10"
-    },
-    "C11": {
-      "alias": "colorcet:CET_C11"
-    },
-    "C2": {
-      "alias": "colorcet:CET_C2"
-    },
-    "C3": {
-      "alias": "colorcet:CET_C3"
-    },
-    "C4": {
-      "alias": "colorcet:CET_C4"
-    },
-    "C5": {
-      "alias": "colorcet:CET_C5"
-    },
-    "C6": {
-      "alias": "colorcet:CET_C6"
-    },
-    "C7": {
-      "alias": "colorcet:CET_C7"
-    },
-    "C8": {
-      "alias": "colorcet:CET_C8"
-    },
-    "C9": {
-      "alias": "colorcet:CET_C9"
-    },
     "CET_C1": {
+      "aliases": [
+        "cyclic_mrybm_35-75_c68_n256"
+      ],
       "category": "cyclic",
       "data": "cmap.data.colorcet.CET_C1:data",
       "info": "Cyclic: magenta - red - yellow - blue. Alows four orientations/phase angles to be visulaised."
     },
     "CET_C10": {
+      "aliases": [
+        "cyclic-isoluminant colour circle_mgbm_67_c31_n256"
+      ],
       "category": "cyclic",
       "data": "cmap.data.colorcet.CET_C10:data",
       "info": "Cyclic: isoluminant"
     },
     "CET_C11": {
+      "aliases": [
+        "cyclic_bgrmb_35-70_c75_n256"
+      ],
       "category": "cyclic",
       "data": "cmap.data.colorcet.CET_C11:data",
       "info": "Cyclic: blue - green - red - magenta. Allows four orientations/phase angles to be visulaised."
     },
     "CET_C2": {
+      "aliases": [
+        "cyclic_mygbm_30-95_c78_n256",
+        "phase4"
+      ],
       "category": "cyclic",
       "data": "cmap.data.colorcet.CET_C2:data",
       "info": "Cyclic: magenta - yellow - green - blue. Alows four orientations/phase angles to be visualised."
     },
     "CET_C3": {
+      "aliases": [
+        "cyclic_wrkbw_10-90_c43_n256"
+      ],
       "category": "cyclic",
       "data": "cmap.data.colorcet.CET_C3:data",
       "info": "Cyclic: white - red - black - blue"
     },
     "CET_C4": {
+      "aliases": [
+        "cyclic_wrwbw_40-90_c42_n256",
+        "phase2"
+      ],
       "category": "cyclic",
       "data": "cmap.data.colorcet.CET_C4:data",
       "info": "Cyclic: white - red - white - blue. Good if you just want to visualise +ve and -ve phase"
     },
     "CET_C5": {
+      "aliases": [
+        "cyclic_grey_15-85_c0_n256",
+        "cyclicgrey"
+      ],
       "category": "cyclic",
       "data": "cmap.data.colorcet.CET_C5:data",
       "info": "Cyclic: greyscale"
     },
     "CET_C6": {
+      "aliases": [
+        "cyclic_rygcbmr_50-90_c64_n256"
+      ],
       "category": "cyclic",
       "data": "cmap.data.colorcet.CET_C6:data",
       "info": "Six colour cyclic with primaries and secondaries matched in lightness."
     },
     "CET_C7": {
+      "aliases": [
+        "cyclic_ymcgy_60-90_c67_n256"
+      ],
       "category": "cyclic",
       "data": "cmap.data.colorcet.CET_C7:data",
       "info": "Cyclic Yellow - Magenta - Cyan - Green - Yellow "
     },
     "CET_C8": {
+      "aliases": [
+        "cyclic_mygbm_50-90_c46_n256"
+      ],
       "category": "cyclic",
       "data": "cmap.data.colorcet.CET_C8:data",
       "info": "Cyclic: low contrast colour ellipse"
     },
     "CET_C9": {
+      "aliases": [
+        "cyclic_mybm_20-100_c48_n256"
+      ],
       "category": "cyclic",
       "data": "cmap.data.colorcet.CET_C9:data",
       "info": "Cyclic: colour ellipse"
     },
     "CET_CBC1": {
+      "aliases": [
+        "cyclic-protanopic-deuteranopic_bwyk_16-96_c31_n256"
+      ],
       "category": "cyclic",
       "data": "cmap.data.colorcet.CET_CBC1:data",
       "info": "4-phase cyclic map blue-white-yellow-black",
@@ -129,6 +108,9 @@
       ]
     },
     "CET_CBC2": {
+      "aliases": [
+        "cyclic-protanopic-deuteranopic_wywb_55-96_c33_n256"
+      ],
       "category": "cyclic",
       "data": "cmap.data.colorcet.CET_CBC2:data",
       "info": "2-phase cyclic map white-yellow-white-blue",
@@ -139,6 +121,9 @@
       ]
     },
     "CET_CBD1": {
+      "aliases": [
+        "diverging-protanopic-deuteranopic_bwy_60-95_c32_n256"
+      ],
       "category": "diverging",
       "data": "cmap.data.colorcet.CET_CBD1:data",
       "info": "Diverging map blue-white-yellow",
@@ -149,6 +134,9 @@
       ]
     },
     "CET_CBD2": {
+      "aliases": [
+        "diverging-linear-protanopic-deuteranopic_bjy_57-89_c34_n256"
+      ],
       "category": "diverging",
       "data": "cmap.data.colorcet.CET_CBD2:data",
       "info": "Diverging-linear map blue-grey-yellow",
@@ -159,6 +147,9 @@
       ]
     },
     "CET_CBL1": {
+      "aliases": [
+        "linear-protanopic-deuteranopic_kbjyw_5-95_c25_n256"
+      ],
       "category": "sequential",
       "data": "cmap.data.colorcet.CET_CBL1:data",
       "info": "Linear map for Protanopic/Deuteranopic viewers",
@@ -169,6 +160,9 @@
       ]
     },
     "CET_CBL2": {
+      "aliases": [
+        "linear-protanopic-deuteranopic_kbw_5-98_c40_n256"
+      ],
       "category": "sequential",
       "data": "cmap.data.colorcet.CET_CBL2:data",
       "info": "Linear map with maximal chroma for Protanopic/Deuteranopic viewers",
@@ -179,6 +173,9 @@
       ]
     },
     "CET_CBL3": {
+      "aliases": [
+        "linear-protanopic-deuteranopic_kbw_5-95_c34_n256"
+      ],
       "category": "sequential",
       "data": "cmap.data.colorcet.CET_CBL3:data",
       "info": "Linear blue map for Protanopic/Deuteranopic viewers",
@@ -189,6 +186,9 @@
       ]
     },
     "CET_CBL4": {
+      "aliases": [
+        "linear-protanopic-deuteranopic_kyw_5-95_c49_n256"
+      ],
       "category": "sequential",
       "data": "cmap.data.colorcet.CET_CBL4:data",
       "info": "Linear yellow map for Protanopic/Deuteranopic viewers",
@@ -199,6 +199,9 @@
       ]
     },
     "CET_CBTC1": {
+      "aliases": [
+        "cyclic-tritanopic_cwrk_40-100_c20_n256"
+      ],
       "category": "cyclic",
       "data": "cmap.data.colorcet.CET_CBTC1:data",
       "info": "4-phase tritanopic cyclic map",
@@ -208,6 +211,9 @@
       ]
     },
     "CET_CBTC2": {
+      "aliases": [
+        "cyclic-tritanopic_wrwc_70-100_c20_n256"
+      ],
       "category": "cyclic",
       "data": "cmap.data.colorcet.CET_CBTC2:data",
       "info": "2-phase tritanopic cyclic map",
@@ -217,6 +223,9 @@
       ]
     },
     "CET_CBTD1": {
+      "aliases": [
+        "diverging-tritanopic_cwr_75-98_c20_n256"
+      ],
       "category": "diverging",
       "data": "cmap.data.colorcet.CET_CBTD1:data",
       "info": "Tritanopic diverging map",
@@ -226,6 +235,9 @@
       ]
     },
     "CET_CBTL1": {
+      "aliases": [
+        "linear-tritanopic_krjcw_5-98_c46_n256"
+      ],
       "category": "sequential",
       "data": "cmap.data.colorcet.CET_CBTL1:data",
       "info": "Tritanopic linear map with maximal chroma",
@@ -235,6 +247,9 @@
       ]
     },
     "CET_CBTL2": {
+      "aliases": [
+        "linear-tritanopic_krjcw_5-95_c24_n256"
+      ],
       "category": "sequential",
       "data": "cmap.data.colorcet.CET_CBTL2:data",
       "info": "Tritanopic linear map",
@@ -244,6 +259,9 @@
       ]
     },
     "CET_CBTL3": {
+      "aliases": [
+        "linear-tritanopic_kcw_5-95_c22_n256"
+      ],
       "category": "sequential",
       "data": "cmap.data.colorcet.CET_CBTL3:data",
       "info": "Tritanopic linear blue map",
@@ -253,6 +271,9 @@
       ]
     },
     "CET_CBTL4": {
+      "aliases": [
+        "linear-tritanopic_krw_5-95_c46_n256"
+      ],
       "category": "sequential",
       "data": "cmap.data.colorcet.CET_CBTL4:data",
       "info": "Tritanopic linear red/heat map",
@@ -262,740 +283,439 @@
       ]
     },
     "CET_D1": {
+      "aliases": [
+        "D01",
+        "D1",
+        "bwr",
+        "coolwarm",
+        "diverging_bwr_40-95_c42_n256"
+      ],
       "category": "diverging",
       "data": "cmap.data.colorcet.CET_D1:data",
       "info": "Classic diverging blue - white - red colour map. End colours are matched in lightness and chroma"
     },
     "CET_D10": {
+      "aliases": [
+        "D10",
+        "diverging_cwm_80-100_c22_n256"
+      ],
       "category": "diverging",
       "data": "cmap.data.colorcet.CET_D10:data",
       "info": "Diverging low contrast cyan - white - magenta colour map.  Good in conjunction with relief shading"
     },
     "CET_D11": {
+      "aliases": [
+        "D11",
+        "diverging-isoluminant_cjo_70_c25_n256"
+      ],
       "category": "diverging",
       "data": "cmap.data.colorcet.CET_D11:data",
       "info": "Diverging isoluminant lightblue - lightgrey - orange colour map"
     },
     "CET_D12": {
+      "aliases": [
+        "D12",
+        "diverging-isoluminant_cjm_75_c23_n256"
+      ],
       "category": "diverging",
       "data": "cmap.data.colorcet.CET_D12:data",
       "info": "Diverging isoluminant lightblue - lightgrey - pink colour map"
     },
     "CET_D13": {
+      "aliases": [
+        "D13",
+        "bwg",
+        "diverging_bwg_20-95_c41_n256"
+      ],
       "category": "diverging",
       "data": "cmap.data.colorcet.CET_D13:data",
       "info": "Diverging blue - white - green colour map"
     },
     "CET_D1A": {
+      "aliases": [
+        "D01A",
+        "D1A",
+        "bwra",
+        "diverging_bwr_20-95_c54_n256"
+      ],
       "category": "diverging",
       "data": "cmap.data.colorcet.CET_D1A:data",
       "info": "Diverging blue - white - red colour map. Similar to D1 but with darker end point colours"
     },
     "CET_D2": {
+      "aliases": [
+        "D02",
+        "D2",
+        "diverging_gwv_55-95_c39_n256",
+        "gwv"
+      ],
       "category": "diverging",
       "data": "cmap.data.colorcet.CET_D2:data",
       "info": "Diverging green - white - violet colour map"
     },
     "CET_D3": {
+      "aliases": [
+        "D03",
+        "D3",
+        "diverging_gwr_55-95_c38_n256",
+        "gwr"
+      ],
       "category": "diverging",
       "data": "cmap.data.colorcet.CET_D3:data",
       "info": "Diverging green - white - red colour map"
     },
     "CET_D4": {
+      "aliases": [
+        "D04",
+        "D4",
+        "bkr",
+        "diverging_bkr_55-10_c35_n256"
+      ],
       "category": "diverging",
       "data": "cmap.data.colorcet.CET_D4:data",
       "info": "Diverging blue - black - red colour map"
     },
     "CET_D5": {
+      "aliases": [
+        "D05",
+        "D5",
+        "diverging_gkr_60-10_c40_n256",
+        "gkr"
+      ],
       "category": "diverging",
       "data": "cmap.data.colorcet.CET_D5:data",
       "info": "Diverging green - black - red colour map"
     },
     "CET_D6": {
+      "aliases": [
+        "D06",
+        "D6",
+        "bky",
+        "diverging_bky_60-10_c30_n256"
+      ],
       "category": "diverging",
       "data": "cmap.data.colorcet.CET_D6:data",
       "info": "Diverging blue - black - yellow colour map"
     },
     "CET_D7": {
+      "aliases": [
+        "D07",
+        "D7",
+        "bjy",
+        "divbjy",
+        "diverging-linear_bjy_30-90_c45_n256"
+      ],
       "category": "diverging",
       "data": "cmap.data.colorcet.CET_D7:data",
       "info": "Linear-diverging blue - grey - yellow colour map. This kind of diverging map has no perceptual dead spot at the centre"
     },
     "CET_D8": {
+      "aliases": [
+        "D08",
+        "D8",
+        "bjr",
+        "diverging-linear_bjr_30-55_c53_n256"
+      ],
       "category": "diverging",
       "data": "cmap.data.colorcet.CET_D8:data",
       "info": "Linear-diverging blue - grey - red"
     },
     "CET_D9": {
+      "aliases": [
+        "D09",
+        "D9",
+        "diverging_bwr_55-98_c37_n256"
+      ],
       "category": "diverging",
       "data": "cmap.data.colorcet.CET_D9:data",
       "info": "Diverging low contrast blue - white - red colour map.  Good in conjunction with relief shading"
     },
     "CET_I1": {
+      "aliases": [
+        "I01",
+        "I1",
+        "isoluminant_cgo_70_c39_n256"
+      ],
       "category": "miscellaneous",
       "data": "cmap.data.colorcet.CET_I1:data",
       "info": "Isoluminant blue to green to orange at lightness 70.  Poor on its own but works well with relief shading"
     },
     "CET_I2": {
+      "aliases": [
+        "I02",
+        "I2",
+        "isoluminant_cgo_80_c38_n256"
+      ],
       "category": "miscellaneous",
       "data": "cmap.data.colorcet.CET_I2:data",
       "info": "Isoluminant blue to green to orange at lightness 80.  Poor on its own but works well with relief shading"
     },
     "CET_I3": {
+      "aliases": [
+        "I03",
+        "I3",
+        "isoluminant_cm_70_c39_n256"
+      ],
       "category": "miscellaneous",
       "data": "cmap.data.colorcet.CET_I3:data",
       "info": "Isoluminant blue to pink at lightness 70.  Poor on its own but works well with relief shading"
     },
     "CET_L1": {
+      "aliases": [
+        "L01",
+        "L1",
+        "gray",
+        "grey",
+        "linear_grey_0-100_c0_n256"
+      ],
       "category": "sequential",
       "data": "cmap.data.colorcet.CET_L1:data",
       "info": "Grey scale"
     },
     "CET_L10": {
+      "aliases": [
+        "L10",
+        "geographic",
+        "linear_gow_60-85_c27_n256"
+      ],
       "category": "sequential",
       "data": "cmap.data.colorcet.CET_L10:data",
       "info": "A \"geographical\" colour map.  Best used with relief shading"
     },
     "CET_L11": {
+      "aliases": [
+        "L11",
+        "geographic2",
+        "linear_gow_65-90_c35_n256"
+      ],
       "category": "sequential",
       "data": "cmap.data.colorcet.CET_L11:data",
       "info": "A lighter \"geographical\" colour map.  Best used with relief shading"
     },
     "CET_L12": {
+      "aliases": [
+        "L12",
+        "depth",
+        "linear_blue_95-50_c20_n256"
+      ],
       "category": "sequential",
       "data": "cmap.data.colorcet.CET_L12:data",
       "info": "A \"water depth\" colour map"
     },
     "CET_L13": {
+      "aliases": [
+        "L13",
+        "linear_ternary-red_0-50_c52_n256",
+        "redternary"
+      ],
       "category": "sequential",
       "data": "cmap.data.colorcet.CET_L13:data",
       "info": "red colour map for ternary images"
     },
     "CET_L14": {
+      "aliases": [
+        "L14",
+        "greenternary",
+        "linear_ternary-green_0-46_c42_n256"
+      ],
       "category": "sequential",
       "data": "cmap.data.colorcet.CET_L14:data",
       "info": "green colour map for ternary images"
     },
     "CET_L15": {
+      "aliases": [
+        "L15",
+        "blueternary",
+        "linear_ternary-blue_0-44_c57_n256"
+      ],
       "category": "sequential",
       "data": "cmap.data.colorcet.CET_L15:data",
       "info": "blue colour map for ternary images"
     },
     "CET_L16": {
+      "aliases": [
+        "L16",
+        "kbgyw",
+        "linear_kbgyw_10-98_c63_n256"
+      ],
       "category": "sequential",
       "data": "cmap.data.colorcet.CET_L16:data",
       "info": "Black-Blue-Green-Yellow-White colour map"
     },
     "CET_L17": {
+      "aliases": [
+        "L17",
+        "linear_worb_100-25_c53_n256",
+        "worb"
+      ],
       "category": "sequential",
       "data": "cmap.data.colorcet.CET_L17:data",
       "info": "White-Orange-Red-Blue, decreasing lightness with increasing saturation"
     },
     "CET_L18": {
+      "aliases": [
+        "L18",
+        "linear_wyor_100-45_c55_n256",
+        "wyor"
+      ],
       "category": "sequential",
       "data": "cmap.data.colorcet.CET_L18:data",
       "info": "White-Yellow-Orange-Red, decreasing lightness with increasing saturation"
     },
     "CET_L19": {
+      "aliases": [
+        "L19",
+        "linear_wcmr_100-45_c42_n256",
+        "wcmr"
+      ],
       "category": "sequential",
       "data": "cmap.data.colorcet.CET_L19:data",
       "info": "White-Cyan-Magenta-Red, decreasing lightness with increasing saturation"
     },
     "CET_L2": {
+      "aliases": [
+        "L02",
+        "L2",
+        "linear_grey_10-95_c0_n256",
+        "reducedgrey"
+      ],
       "category": "sequential",
       "data": "cmap.data.colorcet.CET_L2:data",
       "info": "Grey scale with slightly reduced contrast to avoid display saturation problems"
     },
     "CET_L20": {
+      "aliases": [
+        "L20",
+        "gouldian",
+        "linear_kbgoy_20-95_c57_n256"
+      ],
       "category": "sequential",
       "data": "cmap.data.colorcet.CET_L20:data",
       "info": "Black-Blue-Green-Orange-Yellow map"
     },
     "CET_L3": {
+      "aliases": [
+        "L03",
+        "L3",
+        "fire",
+        "heat",
+        "kryw",
+        "linear_kryw_0-100_c71_n256"
+      ],
       "category": "sequential",
       "data": "cmap.data.colorcet.CET_L3:data",
       "info": "Black-Red-Yellow-White heat colour map"
     },
     "CET_L4": {
+      "aliases": [
+        "L04",
+        "L4",
+        "kry",
+        "linear_kry_0-97_c73_n256",
+        "yellowheat"
+      ],
       "category": "sequential",
       "data": "cmap.data.colorcet.CET_L4:data",
       "info": "Black-Red-Yellow heat colour map"
     },
     "CET_L5": {
+      "aliases": [
+        "L05",
+        "L5",
+        "kgy",
+        "linear_kgy_5-95_c69_n256"
+      ],
       "category": "sequential",
       "data": "cmap.data.colorcet.CET_L5:data",
       "info": "Colour Map along the green edge of CIELAB space"
     },
     "CET_L6": {
+      "aliases": [
+        "L06",
+        "L6",
+        "kbc",
+        "linear_kbc_5-95_c73_n256"
+      ],
       "category": "sequential",
       "data": "cmap.data.colorcet.CET_L6:data",
       "info": "Blue shades running vertically up the blue edge of CIELAB space"
     },
     "CET_L7": {
+      "aliases": [
+        "L07",
+        "L7",
+        "bmw",
+        "linear_bmw_5-95_c86_n256"
+      ],
       "category": "sequential",
       "data": "cmap.data.colorcet.CET_L7:data",
       "info": "Blue-Pink-Light Pink colour map"
     },
     "CET_L8": {
+      "aliases": [
+        "L08",
+        "L8",
+        "bmy",
+        "linear_bmy_10-95_c71_n256"
+      ],
       "category": "sequential",
       "data": "cmap.data.colorcet.CET_L8:data",
       "info": "Blue-Magenta-Yellow highly saturated colour map"
     },
     "CET_L9": {
+      "aliases": [
+        "L09",
+        "L9",
+        "bgyw",
+        "linear_bgyw_20-98_c66_n256"
+      ],
       "category": "sequential",
       "data": "cmap.data.colorcet.CET_L9:data",
       "info": "Blue-green-yellow colour map"
     },
     "CET_R1": {
+      "aliases": [
+        "R01",
+        "R1",
+        "rainbow",
+        "rainbow_bgyrm_35-85_c69_n256"
+      ],
       "category": "miscellaneous",
       "data": "cmap.data.colorcet.CET_R1:data",
       "info": "The least worst rainbow colour map I can devise.  Note there are small perceptual blind spots at yellow and red"
     },
     "CET_R2": {
+      "aliases": [
+        "R02",
+        "R2",
+        "rainbow2",
+        "rainbow_bgyr_35-85_c72_n256"
+      ],
       "category": "miscellaneous",
       "data": "cmap.data.colorcet.CET_R2:data",
       "info": "Reasonable rainbow colour map from blue to red.  Note there is a small perceptual blind spot at yellow"
     },
     "CET_R3": {
+      "aliases": [
+        "R03",
+        "R3",
+        "diverging-rainbow_bgymr_45-85_c67_n256",
+        "rainbow3"
+      ],
       "category": "miscellaneous",
       "data": "cmap.data.colorcet.CET_R3:data",
       "info": "Diverging-rainbow colourmap. Yellow is the central reference colour. The blue and red end points are matched in lightness and chroma"
     },
     "CET_R4": {
+      "aliases": [
+        "R04",
+        "R4",
+        "rainbow4",
+        "rainbow_bgyr_10-90_c83_n256"
+      ],
       "category": "miscellaneous",
       "data": "cmap.data.colorcet.CET_R4:data",
       "info": "Rainbow colour map from blue to red.  Note there is a small perceptual blind spot at yellow"
-    },
-    "D01": {
-      "alias": "colorcet:CET_D1"
-    },
-    "D01A": {
-      "alias": "colorcet:CET_D1A"
-    },
-    "D02": {
-      "alias": "colorcet:CET_D2"
-    },
-    "D03": {
-      "alias": "colorcet:CET_D3"
-    },
-    "D04": {
-      "alias": "colorcet:CET_D4"
-    },
-    "D05": {
-      "alias": "colorcet:CET_D5"
-    },
-    "D06": {
-      "alias": "colorcet:CET_D6"
-    },
-    "D07": {
-      "alias": "colorcet:CET_D7"
-    },
-    "D08": {
-      "alias": "colorcet:CET_D8"
-    },
-    "D09": {
-      "alias": "colorcet:CET_D9"
-    },
-    "D1": {
-      "alias": "colorcet:CET_D1"
-    },
-    "D10": {
-      "alias": "colorcet:CET_D10"
-    },
-    "D11": {
-      "alias": "colorcet:CET_D11"
-    },
-    "D12": {
-      "alias": "colorcet:CET_D12"
-    },
-    "D13": {
-      "alias": "colorcet:CET_D13"
-    },
-    "D1A": {
-      "alias": "colorcet:CET_D1A"
-    },
-    "D2": {
-      "alias": "colorcet:CET_D2"
-    },
-    "D3": {
-      "alias": "colorcet:CET_D3"
-    },
-    "D4": {
-      "alias": "colorcet:CET_D4"
-    },
-    "D5": {
-      "alias": "colorcet:CET_D5"
-    },
-    "D6": {
-      "alias": "colorcet:CET_D6"
-    },
-    "D7": {
-      "alias": "colorcet:CET_D7"
-    },
-    "D8": {
-      "alias": "colorcet:CET_D8"
-    },
-    "D9": {
-      "alias": "colorcet:CET_D9"
-    },
-    "I01": {
-      "alias": "colorcet:CET_I1"
-    },
-    "I02": {
-      "alias": "colorcet:CET_I2"
-    },
-    "I03": {
-      "alias": "colorcet:CET_I3"
-    },
-    "I1": {
-      "alias": "colorcet:CET_I1"
-    },
-    "I2": {
-      "alias": "colorcet:CET_I2"
-    },
-    "I3": {
-      "alias": "colorcet:CET_I3"
-    },
-    "L01": {
-      "alias": "colorcet:CET_L1"
-    },
-    "L02": {
-      "alias": "colorcet:CET_L2"
-    },
-    "L03": {
-      "alias": "colorcet:CET_L3"
-    },
-    "L04": {
-      "alias": "colorcet:CET_L4"
-    },
-    "L05": {
-      "alias": "colorcet:CET_L5"
-    },
-    "L06": {
-      "alias": "colorcet:CET_L6"
-    },
-    "L07": {
-      "alias": "colorcet:CET_L7"
-    },
-    "L08": {
-      "alias": "colorcet:CET_L8"
-    },
-    "L09": {
-      "alias": "colorcet:CET_L9"
-    },
-    "L1": {
-      "alias": "colorcet:CET_L1"
-    },
-    "L10": {
-      "alias": "colorcet:CET_L10"
-    },
-    "L11": {
-      "alias": "colorcet:CET_L11"
-    },
-    "L12": {
-      "alias": "colorcet:CET_L12"
-    },
-    "L13": {
-      "alias": "colorcet:CET_L13"
-    },
-    "L14": {
-      "alias": "colorcet:CET_L14"
-    },
-    "L15": {
-      "alias": "colorcet:CET_L15"
-    },
-    "L16": {
-      "alias": "colorcet:CET_L16"
-    },
-    "L17": {
-      "alias": "colorcet:CET_L17"
-    },
-    "L18": {
-      "alias": "colorcet:CET_L18"
-    },
-    "L19": {
-      "alias": "colorcet:CET_L19"
-    },
-    "L2": {
-      "alias": "colorcet:CET_L2"
-    },
-    "L20": {
-      "alias": "colorcet:CET_L20"
-    },
-    "L3": {
-      "alias": "colorcet:CET_L3"
-    },
-    "L4": {
-      "alias": "colorcet:CET_L4"
-    },
-    "L5": {
-      "alias": "colorcet:CET_L5"
-    },
-    "L6": {
-      "alias": "colorcet:CET_L6"
-    },
-    "L7": {
-      "alias": "colorcet:CET_L7"
-    },
-    "L8": {
-      "alias": "colorcet:CET_L8"
-    },
-    "L9": {
-      "alias": "colorcet:CET_L9"
-    },
-    "R01": {
-      "alias": "colorcet:CET_R1"
-    },
-    "R02": {
-      "alias": "colorcet:CET_R2"
-    },
-    "R03": {
-      "alias": "colorcet:CET_R3"
-    },
-    "R04": {
-      "alias": "colorcet:CET_R4"
-    },
-    "R1": {
-      "alias": "colorcet:CET_R1"
-    },
-    "R2": {
-      "alias": "colorcet:CET_R2"
-    },
-    "R3": {
-      "alias": "colorcet:CET_R3"
-    },
-    "R4": {
-      "alias": "colorcet:CET_R4"
-    },
-    "bgyw": {
-      "alias": "colorcet:CET_L9"
-    },
-    "bjr": {
-      "alias": "colorcet:CET_D8"
-    },
-    "bjy": {
-      "alias": "colorcet:CET_D7"
-    },
-    "bkr": {
-      "alias": "colorcet:CET_D4"
-    },
-    "bky": {
-      "alias": "colorcet:CET_D6"
-    },
-    "blueternary": {
-      "alias": "colorcet:CET_L15"
-    },
-    "bmw": {
-      "alias": "colorcet:CET_L7"
-    },
-    "bmy": {
-      "alias": "colorcet:CET_L8"
-    },
-    "bwg": {
-      "alias": "colorcet:CET_D13"
-    },
-    "bwr": {
-      "alias": "colorcet:CET_D1"
-    },
-    "bwra": {
-      "alias": "colorcet:CET_D1A"
-    },
-    "coolwarm": {
-      "alias": "colorcet:CET_D1"
-    },
-    "cyclic-isoluminant colour circle_mgbm_67_c31_n256": {
-      "alias": "colorcet:CET_C10"
-    },
-    "cyclic-protanopic-deuteranopic_bwyk_16-96_c31_n256": {
-      "alias": "colorcet:CET_CBC1"
-    },
-    "cyclic-protanopic-deuteranopic_wywb_55-96_c33_n256": {
-      "alias": "colorcet:CET_CBC2"
-    },
-    "cyclic-tritanopic_cwrk_40-100_c20_n256": {
-      "alias": "colorcet:CET_CBTC1"
-    },
-    "cyclic-tritanopic_wrwc_70-100_c20_n256": {
-      "alias": "colorcet:CET_CBTC2"
-    },
-    "cyclic_bgrmb_35-70_c75_n256": {
-      "alias": "colorcet:CET_C11"
-    },
-    "cyclic_grey_15-85_c0_n256": {
-      "alias": "colorcet:CET_C5"
-    },
-    "cyclic_mrybm_35-75_c68_n256": {
-      "alias": "colorcet:CET_C1"
-    },
-    "cyclic_mybm_20-100_c48_n256": {
-      "alias": "colorcet:CET_C9"
-    },
-    "cyclic_mygbm_30-95_c78_n256": {
-      "alias": "colorcet:CET_C2"
-    },
-    "cyclic_mygbm_50-90_c46_n256": {
-      "alias": "colorcet:CET_C8"
-    },
-    "cyclic_rygcbmr_50-90_c64_n256": {
-      "alias": "colorcet:CET_C6"
-    },
-    "cyclic_wrkbw_10-90_c43_n256": {
-      "alias": "colorcet:CET_C3"
-    },
-    "cyclic_wrwbw_40-90_c42_n256": {
-      "alias": "colorcet:CET_C4"
-    },
-    "cyclic_ymcgy_60-90_c67_n256": {
-      "alias": "colorcet:CET_C7"
-    },
-    "cyclicgrey": {
-      "alias": "colorcet:CET_C5"
-    },
-    "depth": {
-      "alias": "colorcet:CET_L12"
-    },
-    "divbjy": {
-      "alias": "colorcet:CET_D7"
-    },
-    "diverging-isoluminant_cjm_75_c23_n256": {
-      "alias": "colorcet:CET_D12"
-    },
-    "diverging-isoluminant_cjo_70_c25_n256": {
-      "alias": "colorcet:CET_D11"
-    },
-    "diverging-linear-protanopic-deuteranopic_bjy_57-89_c34_n256": {
-      "alias": "colorcet:CET_CBD2"
-    },
-    "diverging-linear_bjr_30-55_c53_n256": {
-      "alias": "colorcet:CET_D8"
-    },
-    "diverging-linear_bjy_30-90_c45_n256": {
-      "alias": "colorcet:CET_D7"
-    },
-    "diverging-protanopic-deuteranopic_bwy_60-95_c32_n256": {
-      "alias": "colorcet:CET_CBD1"
-    },
-    "diverging-rainbow_bgymr_45-85_c67_n256": {
-      "alias": "colorcet:CET_R3"
-    },
-    "diverging-tritanopic_cwr_75-98_c20_n256": {
-      "alias": "colorcet:CET_CBTD1"
-    },
-    "diverging_bkr_55-10_c35_n256": {
-      "alias": "colorcet:CET_D4"
-    },
-    "diverging_bky_60-10_c30_n256": {
-      "alias": "colorcet:CET_D6"
-    },
-    "diverging_bwg_20-95_c41_n256": {
-      "alias": "colorcet:CET_D13"
-    },
-    "diverging_bwr_20-95_c54_n256": {
-      "alias": "colorcet:CET_D1A"
-    },
-    "diverging_bwr_40-95_c42_n256": {
-      "alias": "colorcet:CET_D1"
-    },
-    "diverging_bwr_55-98_c37_n256": {
-      "alias": "colorcet:CET_D9"
-    },
-    "diverging_cwm_80-100_c22_n256": {
-      "alias": "colorcet:CET_D10"
-    },
-    "diverging_gkr_60-10_c40_n256": {
-      "alias": "colorcet:CET_D5"
-    },
-    "diverging_gwr_55-95_c38_n256": {
-      "alias": "colorcet:CET_D3"
-    },
-    "diverging_gwv_55-95_c39_n256": {
-      "alias": "colorcet:CET_D2"
-    },
-    "fire": {
-      "alias": "colorcet:CET_L3"
-    },
-    "geographic": {
-      "alias": "colorcet:CET_L10"
-    },
-    "geographic2": {
-      "alias": "colorcet:CET_L11"
-    },
-    "gkr": {
-      "alias": "colorcet:CET_D5"
-    },
-    "gouldian": {
-      "alias": "colorcet:CET_L20"
-    },
-    "gray": {
-      "alias": "colorcet:CET_L1"
-    },
-    "greenternary": {
-      "alias": "colorcet:CET_L14"
-    },
-    "grey": {
-      "alias": "colorcet:CET_L1"
-    },
-    "gwr": {
-      "alias": "colorcet:CET_D3"
-    },
-    "gwv": {
-      "alias": "colorcet:CET_D2"
-    },
-    "heat": {
-      "alias": "colorcet:CET_L3"
-    },
-    "isoluminant_cgo_70_c39_n256": {
-      "alias": "colorcet:CET_I1"
-    },
-    "isoluminant_cgo_80_c38_n256": {
-      "alias": "colorcet:CET_I2"
-    },
-    "isoluminant_cm_70_c39_n256": {
-      "alias": "colorcet:CET_I3"
-    },
-    "kbc": {
-      "alias": "colorcet:CET_L6"
-    },
-    "kbgyw": {
-      "alias": "colorcet:CET_L16"
-    },
-    "kgy": {
-      "alias": "colorcet:CET_L5"
-    },
-    "kry": {
-      "alias": "colorcet:CET_L4"
-    },
-    "kryw": {
-      "alias": "colorcet:CET_L3"
-    },
-    "linear-protanopic-deuteranopic_kbjyw_5-95_c25_n256": {
-      "alias": "colorcet:CET_CBL1"
-    },
-    "linear-protanopic-deuteranopic_kbw_5-95_c34_n256": {
-      "alias": "colorcet:CET_CBL3"
-    },
-    "linear-protanopic-deuteranopic_kbw_5-98_c40_n256": {
-      "alias": "colorcet:CET_CBL2"
-    },
-    "linear-protanopic-deuteranopic_kyw_5-95_c49_n256": {
-      "alias": "colorcet:CET_CBL4"
-    },
-    "linear-tritanopic_kcw_5-95_c22_n256": {
-      "alias": "colorcet:CET_CBTL3"
-    },
-    "linear-tritanopic_krjcw_5-95_c24_n256": {
-      "alias": "colorcet:CET_CBTL2"
-    },
-    "linear-tritanopic_krjcw_5-98_c46_n256": {
-      "alias": "colorcet:CET_CBTL1"
-    },
-    "linear-tritanopic_krw_5-95_c46_n256": {
-      "alias": "colorcet:CET_CBTL4"
-    },
-    "linear_bgyw_20-98_c66_n256": {
-      "alias": "colorcet:CET_L9"
-    },
-    "linear_blue_95-50_c20_n256": {
-      "alias": "colorcet:CET_L12"
-    },
-    "linear_bmw_5-95_c86_n256": {
-      "alias": "colorcet:CET_L7"
-    },
-    "linear_bmy_10-95_c71_n256": {
-      "alias": "colorcet:CET_L8"
-    },
-    "linear_gow_60-85_c27_n256": {
-      "alias": "colorcet:CET_L10"
-    },
-    "linear_gow_65-90_c35_n256": {
-      "alias": "colorcet:CET_L11"
-    },
-    "linear_grey_0-100_c0_n256": {
-      "alias": "colorcet:CET_L1"
-    },
-    "linear_grey_10-95_c0_n256": {
-      "alias": "colorcet:CET_L2"
-    },
-    "linear_kbc_5-95_c73_n256": {
-      "alias": "colorcet:CET_L6"
-    },
-    "linear_kbgoy_20-95_c57_n256": {
-      "alias": "colorcet:CET_L20"
-    },
-    "linear_kbgyw_10-98_c63_n256": {
-      "alias": "colorcet:CET_L16"
-    },
-    "linear_kgy_5-95_c69_n256": {
-      "alias": "colorcet:CET_L5"
-    },
-    "linear_kry_0-97_c73_n256": {
-      "alias": "colorcet:CET_L4"
-    },
-    "linear_kryw_0-100_c71_n256": {
-      "alias": "colorcet:CET_L3"
-    },
-    "linear_ternary-blue_0-44_c57_n256": {
-      "alias": "colorcet:CET_L15"
-    },
-    "linear_ternary-green_0-46_c42_n256": {
-      "alias": "colorcet:CET_L14"
-    },
-    "linear_ternary-red_0-50_c52_n256": {
-      "alias": "colorcet:CET_L13"
-    },
-    "linear_wcmr_100-45_c42_n256": {
-      "alias": "colorcet:CET_L19"
-    },
-    "linear_worb_100-25_c53_n256": {
-      "alias": "colorcet:CET_L17"
-    },
-    "linear_wyor_100-45_c55_n256": {
-      "alias": "colorcet:CET_L18"
-    },
-    "phase2": {
-      "alias": "colorcet:CET_C4"
-    },
-    "phase4": {
-      "alias": "colorcet:CET_C2"
-    },
-    "rainbow": {
-      "alias": "colorcet:CET_R1"
-    },
-    "rainbow2": {
-      "alias": "colorcet:CET_R2"
-    },
-    "rainbow3": {
-      "alias": "colorcet:CET_R3"
-    },
-    "rainbow4": {
-      "alias": "colorcet:CET_R4"
-    },
-    "rainbow_bgyr_10-90_c83_n256": {
-      "alias": "colorcet:CET_R4"
-    },
-    "rainbow_bgyr_35-85_c72_n256": {
-      "alias": "colorcet:CET_R2"
-    },
-    "rainbow_bgyrm_35-85_c69_n256": {
-      "alias": "colorcet:CET_R1"
-    },
-    "redternary": {
-      "alias": "colorcet:CET_L13"
-    },
-    "reducedgrey": {
-      "alias": "colorcet:CET_L2"
-    },
-    "wcmr": {
-      "alias": "colorcet:CET_L19"
-    },
-    "worb": {
-      "alias": "colorcet:CET_L17"
-    },
-    "wyor": {
-      "alias": "colorcet:CET_L18"
-    },
-    "yellowheat": {
-      "alias": "colorcet:CET_L4"
     }
   },
   "license": "CC-BY-4.0",

--- a/tests/test_colormap.py
+++ b/tests/test_colormap.py
@@ -174,6 +174,14 @@ def with_or_without_PIL(request, monkeypatch):
     return request.param
 
 
+def test_cmap_info() -> None:
+    cm = Colormap("viridis")
+    assert cm.info
+    assert cm.info.qualified_name == "bids:viridis"
+    assert "matplotlib:viridis" in cm.info.aliases
+    assert "viridis" in cm.info.aliases
+
+
 def test_repr_notebook(with_or_without_PIL) -> None:
     cm = Colormap("viridis")
     assert "viridis" in cm._repr_html_()


### PR DESCRIPTION
closes #10 by adding all of the semantic aliases for colorcet colormaps.  Aliases for all colormaps are now shown in the docs:

<img width="706" alt="Screen Shot 2023-05-06 at 10 39 23 AM" src="https://user-images.githubusercontent.com/1609449/236632926-8d6d190f-6e06-4d1b-ad15-bb5a06e529a4.png">
