### PR TITLE
docs: break hue discontinuity in docs

### DIFF
--- a/docs/javascripts/cmap_charts.js
+++ b/docs/javascripts/cmap_charts.js
@@ -167,9 +167,13 @@ async function makeHSLChart(canvas, data) {
       // If the hue is jumping by more than 90 degrees, insert a null
       // value to break the line
       if (label == "hue" && Math.abs(val - lastval) > 95) {
+        // we just fully skip this point, which does mean a data point is missed
+        // but if we insert a null value, the chartjs hover tooltip will be offset
+        // for all later points
         _data.push({ x: data.x[i], y: null });
+      } else {
+        _data.push({ x: data.x[i], y: val });
       }
-      _data.push({ x: data.x[i], y: val });
       lastval = val;
     }
     datasets.push({


### PR DESCRIPTION
closes #12 by adding a discontinuity for hue wrap-around values in the hue/sat/chroma chart in the docs

<img width="710" alt="Screen Shot 2023-05-06 at 11 14 02 AM" src="https://user-images.githubusercontent.com/1609449/236632666-5fff1627-d80b-4de4-a8e3-2aba2fe845bd.png">
