### PR TITLE
refactor: expose catalog as Colormap classmethod

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,17 +3,9 @@ ci:
   autofix_commit_msg: "style(pre-commit.ci): auto fixes [...]"
   autoupdate_commit_msg: "ci(pre-commit.ci): autoupdate"
 
-default_install_hook_types: [pre-commit, commit-msg]
-
 exclude: ^LICENSE
 
 repos:
-  - repo: https://github.com/compilerla/conventional-pre-commit
-    rev: v2.2.0
-    hooks:
-      - id: conventional-pre-commit
-        stages: [commit-msg]
-
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.4.0
     hooks:

--- a/docs/_gen_cmaps.py
+++ b/docs/_gen_cmaps.py
@@ -1,10 +1,13 @@
 import json
 from pathlib import Path
+from typing import TYPE_CHECKING, cast
 
 import mkdocs_gen_files
 import numpy as np
 
-from cmap import Colormap, _catalog
+if TYPE_CHECKING:
+    from cmap import _catalog
+from cmap import Colormap
 from cmap._util import report
 
 # TODO: convert to jinja
@@ -80,7 +83,7 @@ INCLUDE_DATA = (
 )
 
 
-def build_catalog(catalog: _catalog.Catalog) -> None:
+def build_catalog(catalog: "_catalog.Catalog") -> None:
     for name in catalog:
         if ":" not in name:
             continue
@@ -132,4 +135,4 @@ def _make_aliases_md(aliases: list[str]) -> str:
     return "**Aliases**:  " + ", ".join(f"`{a}`" for a in aliases)
 
 
-build_catalog(_catalog.catalog)
+build_catalog(cast("_catalog.Catalog", Colormap.catalog()))

--- a/docs/_hooks.py
+++ b/docs/_hooks.py
@@ -3,13 +3,17 @@ import re
 import sys
 from functools import partial
 from pathlib import Path
-from typing import Any, Sequence
+from typing import TYPE_CHECKING, Any, Sequence, cast
 
 import numpy as np
 
 from cmap import Colormap, _util
-from cmap._catalog import CATALOG
+
+if TYPE_CHECKING:
+    from cmap._catalog import CatalogDict
 from cmap._color import NAME_TO_RGB
+
+CATALOG = cast("CatalogDict", Colormap.catalog()._data)  # type: ignore
 
 # the template for a single colormap
 CMAP_DIV = """
@@ -64,7 +68,7 @@ def _cmap_expr(match: re.Match) -> str:
 
     {{ cmap_expr: {0: 'blue', 0.5: 'yellow', 1: 'red'} }} -> <div class="cmap">...
     """
-    cm = Colormap(eval(match[1].strip()))
+    cm = Colormap(eval(match[1].strip()))  # noqa: S307
     return CMAP_DIV.format(name="", img=_to_img_tag(cm), class_list="cmap-expr")
 
 
@@ -92,7 +96,7 @@ def _cmap_catalog() -> str:
             continue
         category = details.get("category") or "Uncategorized"
         categories.add(category)
-        classes = ["filterDiv"] + [category.lower()]
+        classes = ["filterDiv", category.lower()]
         lines.append(_cmap_div(cmap_name, classes))
 
     btns = [

--- a/docs/_hooks.py
+++ b/docs/_hooks.py
@@ -68,7 +68,7 @@ def _cmap_expr(match: re.Match) -> str:
 
     {{ cmap_expr: {0: 'blue', 0.5: 'yellow', 1: 'red'} }} -> <div class="cmap">...
     """
-    cm = Colormap(eval(match[1].strip()))  # noqa: S307
+    cm = Colormap(eval(match[1].strip()))
     return CMAP_DIV.format(name="", img=_to_img_tag(cm), class_list="cmap-expr")
 
 

--- a/src/cmap/__init__.py
+++ b/src/cmap/__init__.py
@@ -30,6 +30,33 @@ if TYPE_CHECKING:
             may have multiple aliases.
             """
 
+        def unique_keys(
+            self, prefer_short_names: bool = True, normalized_names: bool = False
+        ) -> set[str]:
+            """Return names that refer to unique colormap data.
+
+            Parameters
+            ----------
+            prefer_short_names : bool, optional
+                If True (default), short names (without the namespace prefix) will be
+                preferred over fully qualified names. In cases where the same short name
+                is used in multiple namespaces, they will *all* be referred to by their
+                fully qualified (namespaced) name.
+            normalized_names : bool, optional
+                If True, return the normalized names of the colormaps.  If False
+                (default), return the original names of the colormaps (which may include
+                spaces and/or capital letters).
+            """
+
+        def short_keys(self) -> set[str]:
+            """Return a set of available short colormap names, without namespace."""
+
+        def namespaced_keys(self) -> set[str]:
+            """Return a set of available short colormap names, with namespace."""
+
+        def resolve(self, name: str) -> str:
+            """Return the fully qualified, normalized name of a colormap or alias."""
+
 else:
     from ._catalog import Catalog, CatalogItem
 

--- a/src/cmap/__init__.py
+++ b/src/cmap/__init__.py
@@ -1,17 +1,43 @@
 """Scientific colormaps for python, without dependencies."""
 from importlib.metadata import PackageNotFoundError, version
+from typing import TYPE_CHECKING, Iterator, Mapping
 
 try:
     __version__ = version("cmap")
 except PackageNotFoundError:  # pragma: no cover
     __version__ = "uninstalled"
 
+
 from ._color import HSLA, HSVA, RGBA, RGBA8, Color
 from ._colormap import Colormap
+
+if TYPE_CHECKING:
+    from ._catalog import CatalogItem
+
+    class Catalog(Mapping[str, CatalogItem]):
+        """Catalog of available colormaps."""
+
+        def __getitem__(self, name: str) -> CatalogItem:
+            """Get a catalog item by name."""
+
+        def __iter__(self) -> Iterator[str]:
+            """Iterate over available colormap keys."""
+
+        def __len__(self) -> int:
+            """Return the number of available colormap keys.
+
+            Note: this is greater than the number of colormaps, as each colormap
+            may have multiple aliases.
+            """
+
+else:
+    from ._catalog import Catalog, CatalogItem
 
 __all__ = [
     "Color",
     "Colormap",
+    "CatalogItem",
+    "Catalog",
     "HSLA",
     "HSVA",
     "RGBA",

--- a/src/cmap/_colormap.py
+++ b/src/cmap/_colormap.py
@@ -10,6 +10,7 @@ from typing import (
     Callable,
     Iterable,
     Iterator,
+    Mapping,
     NamedTuple,
     Sequence,
     Union,
@@ -21,7 +22,6 @@ import numpy as np
 import numpy.typing as npt
 
 from . import _external
-from ._catalog import catalog
 from ._color import Color
 
 if TYPE_CHECKING:
@@ -36,7 +36,7 @@ if TYPE_CHECKING:
     from numpy.typing import ArrayLike, NDArray
     from typing_extensions import TypeAlias, TypedDict, TypeGuard
 
-    from ._catalog import LoadedCatalogItem
+    from ._catalog import CatalogItem
     from ._color import ColorLike
 
     Interpolation = Literal["linear", "nearest"]
@@ -128,7 +128,18 @@ class Colormap:
     identifier: str
     category: str | None
     interpolation: Interpolation
-    info: LoadedCatalogItem | None
+    info: CatalogItem | None
+
+    _catalog_instance: Mapping[str, CatalogItem] | None = None
+
+    @classmethod
+    def catalog(cls) -> Mapping[str, CatalogItem]:
+        """Return the global colormaps catalog."""
+        if cls._catalog_instance is None:
+            from ._catalog import Catalog
+
+            cls._catalog_instance = Catalog()
+        return cls._catalog_instance
 
     def __init__(
         self,
@@ -141,7 +152,7 @@ class Colormap:
     ) -> None:
         if isinstance(value, str):
             rev = value.endswith("_r")
-            info = catalog[value[:-2] if rev else value]
+            info = self.catalog()[value[:-2] if rev else value]
             name = name or f"{info.namespace}:{info.name}"
             category = category or info.category
             self.info = info
@@ -1132,7 +1143,7 @@ def _parse_colorstops(
 
     if isinstance(val, str):
         rev = val.endswith("_r")
-        data = catalog[val[:-2] if rev else val]
+        data = Colormap.catalog()[val[:-2] if rev else val]
         stops = _parse_colorstops(data.data, cls=cls)
         stops._interpolation = _norm_interp(data.interpolation)
         return stops.reversed() if rev else stops

--- a/src/cmap/_external.py
+++ b/src/cmap/_external.py
@@ -163,7 +163,7 @@ def rich_print_colormap(cm: Colormap, width: int | None = None) -> None:
     console = get_console()
     color_cell = Text("")
     # if cm.interpolation == "nearest":
-        # width = len(cm.color_stops)
+    # width = len(cm.color_stops)
     width = width or (console.width - 12)
     for color in cm.iter_colors(width):
         color_cell += Text(" ", style=Style(bgcolor=color.hex[:7]))

--- a/src/cmap/data/matplotlib/record.json
+++ b/src/cmap/data/matplotlib/record.json
@@ -26,7 +26,7 @@
       "data": "cmap.data.matplotlib:brg"
     },
     "bwr": {
-      "category": "miscellaneous",
+      "category": "diverging",
       "data": "cmap.data.matplotlib:bwr"
     },
     "coolwarm": {

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -2,7 +2,8 @@ import numpy as np
 import pytest
 
 from cmap import Colormap
-from cmap._catalog import catalog
+
+catalog = Colormap.catalog()
 
 
 @pytest.mark.filterwarnings("ignore:The name:")
@@ -26,3 +27,14 @@ def test_catalog_data() -> None:
         Colormap(name)  # smoke test
 
     assert len(catalog) > 100
+
+
+def test_lower_map() -> None:
+    # make sure the lower map is the same length as the original
+    # ... i.e. that we have no name collisions
+    assert len(catalog._data_lower) == len(catalog._data)
+
+
+def test_data_loading() -> None:
+    for name in catalog._data:
+        Colormap(name)

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -1,4 +1,5 @@
 from itertools import chain
+
 import numpy as np
 import pytest
 
@@ -43,8 +44,8 @@ def test_data_loading() -> None:
 
 
 def test_catalog_names() -> None:
-    assert 'bids:viridis' in catalog.namespacedKeys()
-    assert 'viridis' in catalog.shortKeys()
+    assert "bids:viridis" in catalog.namespacedKeys()
+    assert "viridis" in catalog.shortKeys()
     assert [
         catalog.resolve(x) for x in chain(catalog.shortKeys(), catalog.namespacedKeys())
     ]

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -32,9 +32,9 @@ def test_catalog_data() -> None:
 def test_lower_map() -> None:
     # make sure the lower map is the same length as the original
     # ... i.e. that we have no name collisions
-    assert len(catalog._data_lower) == len(catalog._data)
+    assert len(catalog._data) == len(catalog._data)
 
 
 def test_data_loading() -> None:
-    for name in catalog._data:
+    for name in catalog._original_names:
         Colormap(name)

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -49,3 +49,5 @@ def test_catalog_names() -> None:
     assert [
         catalog.resolve(x) for x in chain(catalog.shortKeys(), catalog.namespacedKeys())
     ]
+    with pytest.raises(KeyError):
+        catalog.resolve("not-a-cmap")

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -1,9 +1,11 @@
+from itertools import chain
 import numpy as np
 import pytest
 
 from cmap import Colormap
+from cmap._catalog import Catalog
 
-catalog = Colormap.catalog()
+catalog = Catalog()
 
 
 @pytest.mark.filterwarnings("ignore:The name:")
@@ -38,3 +40,11 @@ def test_lower_map() -> None:
 def test_data_loading() -> None:
     for name in catalog._original_names:
         Colormap(name)
+
+
+def test_catalog_names() -> None:
+    assert 'bids:viridis' in catalog.namespacedKeys()
+    assert 'viridis' in catalog.shortKeys()
+    assert [
+        catalog.resolve(x) for x in chain(catalog.shortKeys(), catalog.namespacedKeys())
+    ]

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -44,10 +44,23 @@ def test_data_loading() -> None:
 
 
 def test_catalog_names() -> None:
-    assert "bids:viridis" in catalog.namespacedKeys()
-    assert "viridis" in catalog.shortKeys()
+    assert "bids:viridis" in catalog.namespaced_keys()
+    assert "viridis" in catalog.short_keys()
     assert [
-        catalog.resolve(x) for x in chain(catalog.shortKeys(), catalog.namespacedKeys())
+        catalog.resolve(x)
+        for x in chain(catalog.short_keys(), catalog.namespaced_keys())
     ]
     with pytest.raises(KeyError):
         catalog.resolve("not-a-cmap")
+
+    unique = catalog.unique_keys(prefer_short_names=True, normalized_names=False)
+    assert "ice" not in unique
+    assert "viridis" in unique
+    assert "cmocean:ice" in unique
+    assert "YlGn" in unique
+    unique = catalog.unique_keys(prefer_short_names=False, normalized_names=True)
+    assert "colorbrewer:ylgn" in unique
+    assert "colorbrewer:YlGn" not in unique
+    assert "viridis" not in unique
+    assert "bids:viridis" in unique
+    assert "matplotlib:viridis" not in unique

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -24,7 +24,7 @@ catalog = Colormap.catalog()
 def test_matplotlib_name_parity() -> None:
     if not MPL_CMAPS:
         pytest.skip("matplotlib not installed")
-    if missing := (MPL_CMAPS - set(catalog._data)):
+    if missing := (MPL_CMAPS - set(catalog._original_names)):
         raise AssertionError(f"missing cmap keys from matplotlib: {missing}")
 
 
@@ -43,7 +43,7 @@ def test_napari_name_parity() -> None:
         if not n.endswith(("_r", " r"))
     }
 
-    lower_names = set(catalog._data_lower)
+    lower_names = set(catalog._data)
     if missing := (napari_cmaps - lower_names):
         # NOTE: there are a number of colormap names in vispy that are too specific
         # to be included in the main catalog.

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -4,7 +4,7 @@ import numpy as np
 import numpy.testing as npt
 import pytest
 
-from cmap import Colormap, _catalog
+from cmap import Colormap
 
 try:
     import matplotlib as mpl
@@ -18,22 +18,13 @@ _GRADIENT = np.linspace(0, 1, 256)
 if TYPE_CHECKING:
     from matplotlib.colors import Colormap as MPLColormap
 
-
-def test_lower_map() -> None:
-    # make sure the lower map is the same length as the original
-    # ... i.e. that we have no name collisions
-    assert len(_catalog._CATALOG_LOWER) == len(_catalog.CATALOG)
-
-
-def test_data_loading() -> None:
-    for name in _catalog.CATALOG:
-        Colormap(name)
+catalog = Colormap.catalog()
 
 
 def test_matplotlib_name_parity() -> None:
     if not MPL_CMAPS:
         pytest.skip("matplotlib not installed")
-    if missing := (MPL_CMAPS - set(_catalog.CATALOG)):
+    if missing := (MPL_CMAPS - set(catalog._data)):
         raise AssertionError(f"missing cmap keys from matplotlib: {missing}")
 
 
@@ -52,14 +43,14 @@ def test_napari_name_parity() -> None:
         if not n.endswith(("_r", " r"))
     }
 
-    catalog = set(_catalog._CATALOG_LOWER)
-    if missing := (napari_cmaps - catalog):
+    lower_names = set(catalog._data_lower)
+    if missing := (napari_cmaps - lower_names):
         # NOTE: there are a number of colormap names in vispy that are too specific
         # to be included in the main catalog.
         # They are added under the `vispy_` prefix.  none of these are "publicly" used
         # by napari, but we make sure they're available as vispy+name here.
         for m in list(missing):
-            if f"vispy_{m}" in catalog:
+            if f"vispy_{m}" in lower_names:
                 missing.remove(m)
     if missing:
         raise AssertionError(f"missing cmap keys from napari: {missing}")


### PR DESCRIPTION
This PR is working towards making it easier to query the available colormap keys.  It adds a couple of public conveniences:

```python
from cmap import Colormap

# access global catalog
catalog = Colormap.catalog()

# various ways to query for available keys:


def unique_keys(
    self, prefer_short_names: bool = True, normalized_names: bool = False
) -> set[str]:
    """Return names that refer to unique colormap data.

    Parameters
    ----------
    prefer_short_names : bool, optional
        If True (default), short names (without the namespace prefix) will be
        preferred over fully qualified names. In cases where the same short name
        is used in multiple namespaces, they will *all* be referred to by their
        fully qualified (namespaced) name.
    normalized_names : bool, optional
        If True, return the normalized names of the colormaps.  If False
        (default), return the original names of the colormaps (which may include
        spaces and/or capital letters).
    """

def short_keys(self) -> set[str]:
    """Return a set of available short colormap names, without namespace."""

def namespaced_keys(self) -> set[str]:
    """Return a set of available short colormap names, with namespace."""

def resolve(self, name: str) -> str:
    """Return the fully qualified, normalized name of a colormap or alias."""
```

