### PR TITLE
fix: fix for issues in mpl 3.8.0

### DIFF
--- a/src/cmap/_external.py
+++ b/src/cmap/_external.py
@@ -27,9 +27,22 @@ def to_mpl(
 
     if cm.interpolation == "nearest":
         return mplc.ListedColormap(colors=cm.color_stops.color_array, name=cm.name)
-    return mplc.LinearSegmentedColormap.from_list(
-        cm.name, cm.color_stops, N=N, gamma=gamma
-    )
+
+    try:
+        return mplc.LinearSegmentedColormap.from_list(
+            cm.name, cm.color_stops, N=N, gamma=gamma
+        )
+    except ValueError as e:
+        from matplotlib import __version__
+
+        # broken in matplotlib 3.8.0, fixed by
+        # https://github.com/matplotlib/matplotlib/pull/26952
+        if len(cm.color_stops) == 2 and __version__ == "3.8.0":
+            raise ValueError(
+                "matplotlib 3.8.0 has a bug that prevents creating a colormap "
+                "from only two colors.  Please upgrade or downgrade matplotlib."
+            ) from e
+        raise
 
 
 def to_vispy(cm: Colormap) -> VispyColormap:

--- a/src/cmap/data/matlab/record.json
+++ b/src/cmap/data/matlab/record.json
@@ -25,10 +25,6 @@
       "category": "sequential",
       "data": "cmap.data.matlab:gray"
     },
-    "grays": {
-      "category": "sequential",
-      "data": "cmap.data.matlab:gray"
-    },
     "hot": {
       "category": "sequential",
       "data": "cmap.data.matlab:hot"

--- a/src/cmap/data/matplotlib/record.json
+++ b/src/cmap/data/matplotlib/record.json
@@ -10,6 +10,9 @@
       "license": "BSD-2-Clause",
       "source": "https://www.mathworks.com/matlabcentral/fileexchange/2662-cmrmap-m"
     },
+    "Grays": {
+      "alias": "colorbrewer:Greys"
+    },
     "Wistia": {
       "category": "sequential",
       "data": "cmap.data.matplotlib._wistia:Wistia",
@@ -43,6 +46,9 @@
     "gist_gray": {
       "alias": "cmap:white"
     },
+    "gist_grey": {
+      "alias": "cmap:white"
+    },
     "gist_heat": {
       "alias": "yorick:heat"
     },
@@ -57,6 +63,12 @@
     },
     "gist_yarg": {
       "alias": "yorick:yarg"
+    },
+    "gist_yerg": {
+      "alias": "yorick:yarg"
+    },
+    "grey": {
+      "alias": "cmap:white"
     },
     "inferno": {
       "alias": "bids:inferno"

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -62,7 +62,12 @@ def test_matplotlib_image_parity(name: str) -> None:
     interp = not isinstance(mpl_map, mpl.colors.ListedColormap)
     interp = not isinstance(mpl_map, mpl.colors.ListedColormap)
     our_map = Colormap(name, interpolation=interp)
-    our_map_to_mpl = our_map.to_mpl()
+    try:
+        our_map_to_mpl = our_map.to_mpl()
+    except ValueError as e:
+        if "3.8.0" in str(e):
+            # allow fails on a couple colormaps that are broken in matplotlib 3.8.0
+            return
     img1 = mpl_map(_GRADIENT)
     img2 = our_map_to_mpl(_GRADIENT)
     img3 = our_map(_GRADIENT)


### PR DESCRIPTION
a few changes to accomodate mpl 3.8.0.
One issue still remains with a couple colormaps and was fixed by https://github.com/matplotlib/matplotlib/pull/26952
