### PR TITLE
feat: add shifted method

### DIFF
--- a/tests/test_colormap.py
+++ b/tests/test_colormap.py
@@ -215,3 +215,9 @@ def test_with_extremes() -> None:
 
     assert cm2.under_color == cm.under_color == Color("green")
     assert "under" in cm2._repr_html_()
+
+
+def test_shifted() -> None:
+    cm = Colormap(["red", "blue", "green", "yellow"])
+    assert "shifted0.3" in cm.shifted(0.3).name
+    assert cm.shifted().shifted() == cm

--- a/tests/test_colormap.py
+++ b/tests/test_colormap.py
@@ -219,5 +219,13 @@ def test_with_extremes() -> None:
 
 def test_shifted() -> None:
     cm = Colormap(["red", "blue", "green", "yellow"])
+    assert cm.shifted(1) == cm
     assert "shifted0.3" in cm.shifted(0.3).name
+    # two shifts of 0.5 should give the original array
+    assert cm.shifted().shifted() == cm
+
+    cm = Colormap("viridis")
+    # forward and backward shifts should cancel out
+    assert cm.shifted(0.5).shifted(-0.5) == cm
+    # two shifts of 0.5 should give the original array
     assert cm.shifted().shifted() == cm

--- a/tests/test_colormap.py
+++ b/tests/test_colormap.py
@@ -218,11 +218,16 @@ def test_with_extremes() -> None:
 
 
 def test_shifted() -> None:
-    cm = Colormap(["red", "blue", "green", "yellow"])
+    cm = Colormap(["red", "blue", "yellow"])
     assert cm.shifted(1) == cm
     assert "shifted0.3" in cm.shifted(0.3).name
     # two shifts of 0.5 should give the original array
     assert cm.shifted().shifted() == cm
+
+    wrapped = cm.shifted(0.2, mode="wrap")
+    assert wrapped == Colormap([(0.2, "yellow"), (0.2, "red"), (0.7, "blue")])
+    clipped = cm.shifted(0.5, mode="clip")
+    assert clipped == Colormap([(0.5, "red"), (1, "blue")])
 
     cm = Colormap("viridis")
     # forward and backward shifts should cancel out


### PR DESCRIPTION
closes #17

adds a `Colormap.shifted()` method that can shift the colorstops of any colormap (useful for cyclic cmaps).  Has two modes: wrap (wraparound shifted values) and clip (pin to edge value)