### PR TITLE
docs: make colormap attributes more visible

### DIFF
--- a/docs/api/colormap.md
+++ b/docs/api/colormap.md
@@ -3,3 +3,7 @@
 ::: cmap.Colormap
     options:
         filters: ['(__call__|^[^_])']
+
+::: cmap.ColorStops
+
+::: cmap._colormap.ColorStop

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -102,6 +102,8 @@ plugins:
             annotations_path: "source" # default is 'brief'
             show_bases: false # default is true
             show_source: false # default is true
+            docstring_section_style: list
+            merge_init_into_class: true
 
 extra_css:
   - stylesheets/extra.css

--- a/src/cmap/__init__.py
+++ b/src/cmap/__init__.py
@@ -10,7 +10,7 @@ except PackageNotFoundError:  # pragma: no cover
 
 
 from ._color import HSLA, HSVA, RGBA, RGBA8, Color
-from ._colormap import Colormap
+from ._colormap import Colormap, ColorStops
 
 if TYPE_CHECKING:
     from ._catalog import CatalogItem
@@ -62,10 +62,11 @@ else:
     from ._catalog import Catalog, CatalogItem
 
 __all__ = [
+    "Catalog",
+    "CatalogItem",
     "Color",
     "Colormap",
-    "CatalogItem",
-    "Catalog",
+    "ColorStops",
     "HSLA",
     "HSVA",
     "RGBA",

--- a/src/cmap/_external.py
+++ b/src/cmap/_external.py
@@ -49,9 +49,9 @@ def to_mpl(
             raise
 
     return mpl_cm.with_extremes(
-        bad=cm.bad_color,  # type: ignore
-        over=cm.over_color,  # type: ignore
-        under=cm.under_color,  # type: ignore
+        bad=cm.bad_color,
+        over=cm.over_color,
+        under=cm.under_color,
     )
 
 


### PR DESCRIPTION
@andy-sweet noted that `Colormap.color_stops` is hard to find (but it's an important attribute to know about).  this fixes that and generally touches up the docs a bit