### PR TITLE
fix: fixes for numpy2

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,4 +35,4 @@ repos:
       - id: mypy
         files: "^src/"
         additional_dependencies:
-          - numpy
+          - numpy>=2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ test_thirdparty = [
     "colorspacious",
     "bokeh",
     "colour",
-    "napari",
+    "napari>=0.4.19",
     "plotly",
     "pydantic",
     "pydantic-extra-types",

--- a/src/cmap/_color.py
+++ b/src/cmap/_color.py
@@ -476,7 +476,7 @@ class Color:
         if self.name:
             arg: str | tuple = self.name
         else:
-            arg = tuple(round(x, 4) for x in tuple(self._rgba))
+            arg = tuple(round(float(x), 4) for x in tuple(self._rgba))
             if self._rgba.a == 1:
                 arg = arg[:3]
         return f"{self.__class__.__name__}({arg!r})"

--- a/src/cmap/_colormap.py
+++ b/src/cmap/_colormap.py
@@ -354,7 +354,9 @@ class Colormap:
 
         xa = np.array(x, copy=True)
         if not xa.dtype.isnative:
-            xa = xa.byteswap().newbyteorder()  # Native byteorder is faster.
+            # Native byteorder is faster.
+            native: Literal[">", "<"] = ">" if xa.dtype.byteorder in ("<", "=") else "<"
+            xa = xa.view(xa.dtype.newbyteorder(native))
         if xa.dtype.kind == "f":
             xa *= N
             # xa == 1 (== N after multiplication) is not out of range.
@@ -974,7 +976,7 @@ class ColorStops(Sequence[ColorStop]):
                 rev = " <reversed>"
             name = f"{f.__module__}{f.__qualname__}"
             return f"ColorStops(lut_func={name!r}{rev})"
-        m = ",\n  ".join(repr((pos, Color(rgba))) for pos, *rgba in self._stops)
+        m = ",\n  ".join(repr((pos.item(), Color(rgba))) for pos, *rgba in self._stops)
         return f"ColorStops(\n  {m}\n)"
 
     def __eq__(self, __o: object) -> bool:

--- a/tests/test_colormap.py
+++ b/tests/test_colormap.py
@@ -130,7 +130,9 @@ def test_colormap_apply() -> None:
     img = np.zeros((10, 10))
     assert cmap1(img).shape == (10, 10, 4)
     # non-native byte order
-    assert cmap1(img.byteswap().newbyteorder()).shape == (10, 10, 4)
+    new_order = ">" if sys.byteorder == "little" else "<"
+    swapped = img.view(img.dtype.newbyteorder(new_order))
+    assert cmap1(swapped).shape == (10, 10, 4)
 
 
 def test_fill_stops() -> None:


### PR DESCRIPTION
`arr.byteswap().newbyteorder()` is gone